### PR TITLE
chore: normalize repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/samchungy/eslint-plugin-import-zod.git"
+    "url": "git+https://github.com/samchungy/eslint-plugin-import-zod.git"
   },
   "scripts": {
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- normalize the package repository metadata from SSH to HTTPS git URL
- leave runtime code, dependencies, package entries, and version unchanged

## Validation

- node metadata assertion
- npm pack --dry-run --ignore-scripts --json
- pnpm test
- pnpm build
- git diff --check
